### PR TITLE
Add support for self hosted deployments

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,11 +15,12 @@ import (
 	"time"
 )
 
-var domainFlag = flag.String("domain", "gopkg.in", "The domain in which this app is used")
 var httpFlag = flag.String("http", ":8080", "Serve HTTP at given address")
 var httpsFlag = flag.String("https", "", "Serve HTTPS at given address")
 var certFlag = flag.String("cert", "", "Use the provided TLS certificate")
 var keyFlag = flag.String("key", "", "Use the provided TLS key")
+var domainFlag = flag.String("domain", "gopkg.in", "Domain name")
+var githubFlag = flag.String("github", "", "Github username")
 
 func main() {
 	if err := run(); err != nil {
@@ -80,6 +81,9 @@ type Repo struct {
 
 // GitHubRoot returns the repository root at GitHub, without a schema.
 func (repo *Repo) GitHubRoot() string {
+	if *githubFlag != "" {
+		return "github.com/" + *githubFlag + "/" + repo.Name
+	}
 	if repo.User == "" {
 		return "github.com/go-" + repo.Name + "/" + repo.Name
 	} else {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 )
 
+var domainFlag = flag.String("domain", "gopkg.in", "The domain in which this app is used")
 var httpFlag = flag.String("http", ":8080", "Serve HTTP at given address")
 var httpsFlag = flag.String("https", "", "Serve HTTPS at given address")
 var certFlag = flag.String("cert", "", "Use the provided TLS certificate")
@@ -104,15 +105,15 @@ func (repo *Repo) GopkgVersionRoot(version Version) string {
 	v := version.String()
 	if repo.OldFormat {
 		if repo.User == "" {
-			return "gopkg.in/" + v + "/" + repo.Name
+			return *domainFlag + "/" + v + "/" + repo.Name
 		} else {
-			return "gopkg.in/" + repo.User + "/" + v + "/" + repo.Name
+			return *domainFlag + "/" + repo.User + "/" + v + "/" + repo.Name
 		}
 	} else {
 		if repo.User == "" {
-			return "gopkg.in/" + repo.Name + "." + v
+			return *domainFlag + "/" + repo.Name + "." + v
 		} else {
-			return "gopkg.in/" + repo.User + "/" + repo.Name + "." + v
+			return *domainFlag + "/" + repo.User + "/" + repo.Name + "." + v
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ var httpsFlag = flag.String("https", "", "Serve HTTPS at given address")
 var certFlag = flag.String("cert", "", "Use the provided TLS certificate")
 var keyFlag = flag.String("key", "", "Use the provided TLS key")
 var domainFlag = flag.String("domain", "gopkg.in", "Domain name")
-var githubFlag = flag.String("github", "", "Github username")
+var userFlag = flag.String("username", "", "Github username")
 
 func main() {
 	if err := run(); err != nil {
@@ -81,14 +81,13 @@ type Repo struct {
 
 // GitHubRoot returns the repository root at GitHub, without a schema.
 func (repo *Repo) GitHubRoot() string {
-	if *githubFlag != "" {
-		return "github.com/" + *githubFlag + "/" + repo.Name
+	if *userFlag != "" {
+		return "github.com/" + *userFlag + "/" + repo.Name
 	}
 	if repo.User == "" {
 		return "github.com/go-" + repo.Name + "/" + repo.Name
-	} else {
-		return "github.com/" + repo.User + "/" + repo.Name
 	}
+	return "github.com/" + repo.User + "/" + repo.Name
 }
 
 // GopkgRoot returns the package root at gopkg.in, without a schema.


### PR DESCRIPTION
resolves #16

For self hosted deployments of gopkg, the `-domain` flag should be used to specify the domain you want to use. For example `go.mysite.com`.

Now your github repositories are `go get`-able with a custom domain. `go get go.mysite.com/user/pkg.v0`.

To make the import path more concise, you could specify your github username using the `-github` flag. The import path `go.mysite.com/pkg.v0` would resolve to `github.com/user/pkg` instead of `github.com/go-pkg/pkg`.
