### PR TITLE
Add support for raw X.Y.Z tags without a "v" prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -290,12 +290,16 @@ func hackedRefs(repo *Repo) (data []byte, versions []Version, err error) {
 			mrefj = hashj
 		}
 
-		if strings.HasPrefix(name, "refs/heads/v") || strings.HasPrefix(name, "refs/tags/v") {
+		if strings.HasPrefix(name, "refs/heads/") || strings.HasPrefix(name, "refs/tags/") {
 			if strings.HasSuffix(name, "^{}") {
 				// Annotated tag is peeled off and overrides the same version just parsed.
 				name = name[:len(name)-3]
 			}
-			v, ok := parseVersion(name[strings.IndexByte(name, 'v'):])
+			// Remove the "refs/" prefix so we can just match on the first /
+			name = name[5:]
+			// Now remove */ too (either "heads/" or "tags/")
+			name = name[strings.IndexByte(name, '/')+1:]
+			v, ok := parseVersion(name)
 			if ok && repo.MajorVersion.Contains(v) && (v == vrefv || !vrefv.IsValid() || vrefv.Less(v)) {
 				vrefv = v
 				vrefi = hashi

--- a/version.go
+++ b/version.go
@@ -51,11 +51,11 @@ func parseVersion(s string) (Version, bool) {
 	if len(s) < 2 {
 		return InvalidVersion, false
 	}
-	if s[0] != 'v' {
-		return InvalidVersion, false
+	i := 0
+	if s[i] == 'v' {
+		i++
 	}
 	v := Version{-1, -1, -1}
-	i := 1
 	v.Major, i = parseVersionPart(s, i)
 	if i < 0 {
 		return InvalidVersion, false


### PR DESCRIPTION
This changes the codebase so that `parseVersion` is the single Source-of-Truth for what a "version" looks like instead of that "v" prefix sneaking in elsewhere too. :smile:

This allows for projects like https://github.com/codegangsta/cli to use gopkg.in since they use version numbers that conform to the gopkg requirements, but are missing that "v" prefix (likely due to personal taste).

I'd also note that I'm very comfortable with Git, so feel free to force me to make changes if you don't like this as-is - I'm happy to amend, etc etc and am not at all attached to this exact implementation. :+1:
