### PR TITLE
Add route to retrieve versions in JSON format

### DIFF
--- a/page.go
+++ b/page.go
@@ -299,7 +299,6 @@ func renderPackagePage(resp http.ResponseWriter, req *http.Request, repo *Repo) 
 		gotResp <- true
 	}()
 
-
 	r := 0
 	for r < wantResps {
 		select {


### PR DESCRIPTION
After seeing #12 and #18 I added a route that's available by ending a path with `/info/versions` that returns all versions and the latest version. I only tested with a repo that doesn't have the user in the path (`curl localhost:8080/yaml.v1/info/versions`) as I couldn't find any "User-owned repositories" that conform to gopkg's standards. 

A problem yet to be solved is getting all versions without specifying a version in the path (`curl localhost:8080/yaml/info/versions`) because it doesn't get past the path regex. I'm not a regex jedi so maybe you could help with that otherwise users have to add a valid version to get all the versions which kind of defeats the purpose.
