### PR TITLE
Specify alternate git domains in the gopkg.in url

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,14 +71,14 @@ func run() error {
 	}
 
 	if *httpFlag != "" {
-		server := httpServer
+		server := *httpServer
 		server.Addr = *httpFlag
 		go func() {
 			ch <- server.ListenAndServe()
 		}()
 	}
 	if *httpsFlag != "" {
-		server := httpServer
+		server := *httpServer
 		server.Addr = *httpsFlag
 		if *acmeFlag != "" {
 			m := autocert.Manager{

--- a/main.go
+++ b/main.go
@@ -251,7 +251,7 @@ func handler(resp http.ResponseWriter, req *http.Request) {
 	repo.SwitchDomain()
 
 	var ok bool
-	repo.MajorVersion, ok = parseVersion(m[3])
+	repo.MajorVersion, ok = parseVersion(m[4])
 	if !ok {
 		sendNotFound(resp, "Version %q improperly considered invalid; please warn the service maintainers.", m[3])
 		return


### PR DESCRIPTION
I hear there are several ideas floating around to implement support to other git repositories outside github.com.

Raising a pull request for small set of changes which I made in a version of gopkg which I use within my company to support multiple github domains from the same gopkg instance.

I'm guessing this idea might be already analysed by you guys, but anyway,
The Idea is to tweak the patternNew regex to accept a git domain route in the url
For example : gopkg.in/{gitdomain.com}/{user}/{repository}.{version}

If the git domain is available users are mandated to provide the git user and repository.
If the user is specified without specifying the domain, repo.domain would get set as the user
To get around this I swapped the git domain and git user on this particular scenario.

Would be great to know if there is a better implementation.
Hope this helps.

Thanks
Rahul