### PR TITLE
Specify alternate git domains in the gopkg.in url

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,14 +71,14 @@ func run() error {
 	}
 
 	if *httpFlag != "" {
-		server := httpServer
+		server := *httpServer
 		server.Addr = *httpFlag
 		go func() {
 			ch <- server.ListenAndServe()
 		}()
 	}
 	if *httpsFlag != "" {
-		server := httpServer
+		server := *httpServer
 		server.Addr = *httpsFlag
 		if *acmeFlag != "" {
 			m := autocert.Manager{

--- a/main.go
+++ b/main.go
@@ -251,7 +251,7 @@ func handler(resp http.ResponseWriter, req *http.Request) {
 	repo.SwitchDomain()
 
 	var ok bool
-	repo.MajorVersion, ok = parseVersion(m[3])
+	repo.MajorVersion, ok = parseVersion(m[4])
 	if !ok {
 		sendNotFound(resp, "Version %q improperly considered invalid; please warn the service maintainers.", m[3])
 		return

--- a/main.go
+++ b/main.go
@@ -191,20 +191,23 @@ func (repo *Repo) GopkgVersionRoot(version Version) string {
 	version.Minor = -1
 	version.Patch = -1
 	v := version.String()
+	host := "gopkg.in/"
 	if repo.OldFormat {
 		if repo.User == "" {
-			return "gopkg.in/" + v + "/" + repo.Name
+			return host + v + "/" + repo.Name
 		}
-		return "gopkg.in/" + repo.User + "/" + v + "/" + repo.Name
+		return host + repo.User + "/" + v + "/" + repo.Name
 	}
-	if repo.User == "" {
-		return "gopkg.in/" + repo.Name + "." + v
+	if repo.Domain == "" && repo.User == "" {
+		return host + repo.Name + "." + v
+	} else if repo.Domain == "" {
+		return host + "/" + repo.User + "/" + repo.Name + "." + v
 	}
-	return "gopkg.in/" + repo.User + "/" + repo.Name + "." + v
+	return host + "/" + repo.Domain + "/" + repo.User + "/" + repo.Name + "." + v
 }
 
 var patternOld = regexp.MustCompile(`^/(?:([a-z0-9][-a-z0-9]+)/)?((?:v0|v[1-9][0-9]*)(?:\.0|\.[1-9][0-9]*){0,2}(?:-unstable)?)/([a-zA-Z][-a-zA-Z0-9]*)(?:\.git)?((?:/[a-zA-Z][-a-zA-Z0-9]*)*)$`)
-var patternNew = regexp.MustCompile(`^/(?:([a-zA-Z0-9][-a-zA-Z0-9]+)/)?(?:([a-zA-Z0-9][-a-zA-Z0-9]+)/)?([a-zA-Z][-.a-zA-Z0-9]*)\.((?:v0|v[1-9][0-9]*)(?:\.0|\.[1-9][0-9]*){0,2}(?:-unstable)?)(?:\.git)?((?:/[a-zA-Z0-9][-.a-zA-Z0-9]*)*)$`)
+var patternNew = regexp.MustCompile(`^/(?:([a-zA-Z0-9][-.a-zA-Z0-9]+)/)?(?:([a-zA-Z0-9][-.a-zA-Z0-9]+)/)?([a-zA-Z][-.a-zA-Z0-9]*)\.((?:v0|v[1-9][0-9]*)(?:\.0|\.[1-9][0-9]*){0,2}(?:-unstable)?)(?:\.git)?((?:/[a-zA-Z0-9][-.a-zA-Z0-9]*)*)$`)
 
 func handler(resp http.ResponseWriter, req *http.Request) {
 	if req.URL.Path == "/health-check" {
@@ -253,7 +256,7 @@ func handler(resp http.ResponseWriter, req *http.Request) {
 	var ok bool
 	repo.MajorVersion, ok = parseVersion(m[4])
 	if !ok {
-		sendNotFound(resp, "Version %q improperly considered invalid; please warn the service maintainers.", m[3])
+		sendNotFound(resp, "Version %q improperly considered invalid; please warn the service maintainers.", m[4])
 		return
 	}
 


### PR DESCRIPTION
I hear there are several ideas floating around to implement support to other git repositories outside github.com.

Raising a pull request for small set of changes which I made in a version of gopkg which I use within my company to support multiple github domains from the same gopkg instance.

I'm guessing this idea might be already analysed by you guys, but anyway,
The Idea is to tweak the patternNew regex to accept a git domain route in the url
For example : gopkg.in/{gitdomain.com}/{user}/{repository}.{version}

If the git domain is available users are mandated to provide the git user and repository.
If the user is specified without specifying the domain, repo.domain would get set as the user
To get around this I swapped the git domain and git user on this particular scenario.

Would be great to know if there is a better implementation.
Hope this helps.

Thanks
Rahul