### PR TITLE
Use same $GIT_URL for upload-pack and ref discovery

### DIFF
--- a/main.go
+++ b/main.go
@@ -353,7 +353,7 @@ func sendNotFound(resp http.ResponseWriter, msg string, args ...interface{}) {
 const refsSuffix = ".git/info/refs?service=git-upload-pack"
 
 func proxyUploadPack(resp http.ResponseWriter, req *http.Request, repo *Repo) {
-	preq, err := http.NewRequest(req.Method, "https://"+repo.GitHubRoot()+"/git-upload-pack", req.Body)
+	preq, err := http.NewRequest(req.Method, "https://"+repo.GitHubRoot()+".git/git-upload-pack", req.Body)
 	if err != nil {
 		resp.WriteHeader(http.StatusInternalServerError)
 		resp.Write([]byte(fmt.Sprintf("Cannot create GitHub request: %v", err)))


### PR DESCRIPTION
The refsSuffix used for reference discovery appends ".git" to the repo name, while the upload pack proxying does not. This can result in a 422 response from GitHub instead of a packfile when trying to clone gopkg.in repos (ie driusan/dgit#129), making gopkg.in URLs uncloneable with some third party git clients.

I'm not sure why GitHub doesn't have this issue when cloning with the official git client, but using the same base git url for both /info/refs and /git-upload-pack appears to fix the issue for dgit while not causing any noticeable regressions with real git when I tested this change locally.