### PR TITLE
snapcraft.yaml: build thyself

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,7 +13,7 @@ plugs:
 
 apps:
     gopkg:
-        command: gopkg
+        command: bin/gopkg
         adapter: none
 
     daemon:
@@ -21,8 +21,16 @@ apps:
         daemon: simple
 
 parts:
-    code:
-        plugin: dump
+    gopkg:
+        plugin: go
         source: .
-        stage:
-            - gopkg
+        go-importpath: niemeyer/gopkg
+        build-packages:
+            - git
+        build-environment:
+            # https://github.com/golang/go/issues/33840
+            - CGO_ENABLED: "0"
+        build-snaps:
+            - go
+        prime:
+            - bin/gopkg


### PR DESCRIPTION
I've been using this to build my test snaps and figured it would be useful to have upstream.

With these changes the snap can now be built on build.snapcraft.org as well as via snapcraft snap.